### PR TITLE
PLFM-9073: Add deploy cdn-webacl

### DIFF
--- a/.github/workflows/build_synapse_cdn_webacl.yml
+++ b/.github/workflows/build_synapse_cdn_webacl.yml
@@ -1,0 +1,65 @@
+---
+name: Migration, Prod to Staging
+
+on:
+  workflow_call:
+    inputs:
+      STACK:
+        required: true
+        type: string
+        description: dev or prod
+
+env:
+   RUNNER_LABEL: deployment-runner
+   INSTANCE_TYPE: t4g.large
+   PATH_TO_SCRIPT: scripts
+   PATH_TO_SOURCE_CODE: src
+
+jobs:
+  # this is necessary to make env values available to later jobs
+  get-env:
+    runs-on: ubuntu-latest
+    steps:
+       - run: echo "null"
+    outputs:
+      RUNNER_LABEL: ${{ env.RUNNER_LABEL }}
+      INSTANCE_TYPE: ${{ env.INSTANCE_TYPE }}
+      PATH_TO_SCRIPT: ${{ env.PATH_TO_SCRIPT }}
+      PATH_TO_SOURCE_CODE: ${{ env.PATH_TO_SOURCE_CODE }}
+
+  ensure-runner-exists:
+    needs: get-env
+    uses: "./.github/workflows/ensure_runner_exists.yml"
+    with:
+      LABEL: ${{ needs.get-env.outputs.RUNNER_LABEL }}
+      INSTANCE_TYPE: ${{ needs.get-env.outputs.INSTANCE_TYPE }}
+      CONTEXT: ${{ vars.CONTEXT }}
+      ROLE_TO_ASSUME: ${{ vars.ROLE_TO_ASSUME }}
+      SYNAPSE_DEPLOYMENT_ROLE: ${{ vars.SYNAPSE_DEPLOYMENT_ROLE }}
+    secrets: inherit
+
+  execute-script:
+    runs-on: ${{ needs.get-env.outputs.RUNNER_LABEL }}
+    needs: [ensure-runner-exists, get-env]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: Sage-Bionetworks/synapse-ops-core
+          ref: main
+          path: ${{ needs.get-env.outputs.PATH_TO_SCRIPT }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: Sage-Bionetworks/Synapse-Migration-Utility
+          ref: develop
+          path: ${{ needs.get-env.outputs.PATH_TO_SOURCE_CODE }}
+
+      - name: Execute script
+        run: >
+          ${{ needs.get-env.outputs.PATH_TO_SCRIPT }}/scripts/build_synapse_cdn_webacl.sh
+          ${{ inputs.STACK }}
+          ${{ needs.get-env.outputs.PATH_TO_SOURCE_CODE }}
+...

--- a/scripts/build_synapse_cdn_webacl.sh
+++ b/scripts/build_synapse_cdn_webacl.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Build Synapse CDN WebACLs
+#
+
+set +x
+
+# dev, staging or prod
+STACK=${1}
+
+# Folder containing source code
+SRC_PATH=${2}
+
+cd $SRC_PATH
+
+mvn clean install
+
+export CMD_PROPS = " -Dorg.sagebionetworks.stack=${STACK}"
+
+java $CMD_PROPS -Xms256m -Xmx2g -cp ./target/stack-builder-0.2.0-SNAPSHOT-jar-with-dependencies.jar org.sagebionetworks.template.cdn.webacl.CdnWebAclBuilderMain


### PR DESCRIPTION
This PR sets up the ops-core part of deploying the webACL for the SynapseCDNs

Requires https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/pull/741

