### PR TITLE
Increase migration timeout

### DIFF
--- a/.github/workflows/migration_prod_staging.yml
+++ b/.github/workflows/migration_prod_staging.yml
@@ -47,6 +47,7 @@ jobs:
   execute-script:
     runs-on: ${{ needs.get-env.outputs.RUNNER_LABEL }}
     needs: [ensure-runner-exists, get-env]
+    timeout-minutes: 2880 # 48 hours
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR increases the timeout for the migration job (expired after 6hrs last night).
If it works, will add to cron job.
