### PR TITLE
Add support to run an arbitrary asynch job

### DIFF
--- a/.github/workflows/code_pipeline_execute_admin_async_job.yml
+++ b/.github/workflows/code_pipeline_execute_admin_async_job.yml
@@ -1,5 +1,5 @@
 ---
-name: Grid session backfill
+name: Execute Admin Asynchronous Job
 
 on:
   workflow_call:

--- a/.github/workflows/code_pipeline_execute_admin_async_job.yml
+++ b/.github/workflows/code_pipeline_execute_admin_async_job.yml
@@ -1,0 +1,43 @@
+---
+name: Grid session backfill
+
+on:
+  workflow_call:
+    inputs:
+      SYNAPSE_HOST:
+        required: true
+        type: string
+        description: The Synapse host to target
+      ASYNC_JOB_PAYLOAD:
+        required: true
+        type: string
+        description: The payload to pass to the async job, in JSON format
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine Pipeline Parameters
+        id: pipeline-params
+        run: |
+          PIPELINE_PARAMETERS=\
+          "CommandToExecute=\"scripts/execute_admin_async_job.sh ${{ inputs.SYNAPSE_HOST }} '${{ inputs.ASYNC_JOB_PAYLOAD }}'\""
+          echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
+    outputs:
+      PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}
+
+  invoke_pipeline:
+    needs: set-up
+    uses: "./.github/workflows/invoke_code_pipeline.yml"
+    with:
+      PIPELINE_PARAMETERS: ${{ needs.set-up.outputs.PIPELINE_PARAMETERS }}
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+      security-events: write
+      statuses: write
+      actions: write
+      checks: write
+...

--- a/scripts/execute_admin_async_job.sh
+++ b/scripts/execute_admin_async_job.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Execute an asynchronous admin job against a Synapse host
+#
+
+SYNAPSE_HOST=${1}
+
+ASYNC_JOB_PAYLOAD=${2}
+
+set +x
+# Retrieve a personal access token for a Synapse admin user from AWS secrets manager
+ACCESS_TOKEN=`aws secretsmanager get-secret-value --secret-id /synapse/admin-pat --query SecretString --output text`
+
+echo $SYNAPSE_HOST/repo/v1/admin/asynchronous/job
+curl --fail-with-body \
+    -X POST \
+    -H "Authorization:Bearer $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$ASYNC_JOB_PAYLOAD" \
+    "$SYNAPSE_HOST/repo/v1/admin/asynchronous/job"

--- a/scripts/execute_admin_async_job.sh
+++ b/scripts/execute_admin_async_job.sh
@@ -37,12 +37,12 @@ while true; do
         "$SYNAPSE_HOST/repo/v1/admin/asynchronous/job/$JOB_ID")
     STATE=$(echo "$STATUS_RESPONSE" | jq -r '.jobState')
     echo "Job state: $STATE"
+    echo "$STATUS_RESPONSE"
     if [ "$STATE" == "COMPLETE" ]; then
         echo "Job completed successfully."
         break
     elif [ "$STATE" == "FAILED" ]; then
         echo "Job failed."
-        echo "$STATUS_RESPONSE"
         exit 2
     fi
     sleep 5

--- a/scripts/execute_admin_async_job.sh
+++ b/scripts/execute_admin_async_job.sh
@@ -12,9 +12,38 @@ set +x
 ACCESS_TOKEN=`aws secretsmanager get-secret-value --secret-id /synapse/admin-pat --query SecretString --output text`
 
 echo $SYNAPSE_HOST/repo/v1/admin/asynchronous/job
-curl --fail-with-body \
-    -X POST \
-    -H "Authorization:Bearer $ACCESS_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d "$ASYNC_JOB_PAYLOAD" \
-    "$SYNAPSE_HOST/repo/v1/admin/asynchronous/job"
+
+# Submit the async job and capture the jobId
+RESPONSE=$(curl --fail-with-body \
+        -X POST \
+        -H "Authorization:Bearer $ACCESS_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$ASYNC_JOB_PAYLOAD" \
+        "$SYNAPSE_HOST/repo/v1/admin/asynchronous/job")
+
+JOB_ID=$(echo "$RESPONSE" | jq -r '.jobId')
+if [ -z "$JOB_ID" ] || [ "$JOB_ID" == "null" ]; then
+    echo "Failed to retrieve jobId from response: $RESPONSE" >&2
+    exit 1
+fi
+
+echo "Submitted job with jobId: $JOB_ID"
+
+# Poll for job status until COMPLETE or FAILED
+STATUS=""
+while true; do
+    STATUS_RESPONSE=$(curl --fail-with-body \
+        -H "Authorization:Bearer $ACCESS_TOKEN" \
+        "$SYNAPSE_HOST/repo/v1/admin/asynchronous/job/$JOB_ID")
+    STATE=$(echo "$STATUS_RESPONSE" | jq -r '.jobState')
+    echo "Job state: $STATE"
+    if [ "$STATE" == "COMPLETE" ]; then
+        echo "Job completed successfully."
+        break
+    elif [ "$STATE" == "FAILED" ]; then
+        echo "Job failed."
+        echo "$STATUS_RESPONSE"
+        exit 2
+    fi
+    sleep 5
+done


### PR DESCRIPTION
This PR adds support to call /admin/asynchronous/job with a job payload to execute a job on a Synapse host.
Immediate use would be to run backfill job for managed access requirements forums.