### PR TITLE
[PLFM-9614] Set placeholder Beanstalk numbers in build_synapse_dev_stack.sh

### DIFF
--- a/scripts/build_synapse_dev_stack.sh
+++ b/scripts/build_synapse_dev_stack.sh
@@ -18,7 +18,9 @@ mvn clean install
 export CMD_PROPS=\
 " -Dorg.sagebionetworks.stack=dev"\
 " -Dorg.sagebionetworks.instance=${INSTANCE}"\
-" -Dorg.sagebionetworks.vpc.subnet.color=Green"
+" -Dorg.sagebionetworks.vpc.subnet.color=Green"\
+" -Dorg.sagebionetworks.beanstalk.number.repo=0"\
+" -Dorg.sagebionetworks.beanstalk.number.workers=0"
 
 java -Xms256m -Xmx2g -cp ./target/stack-builder-0.2.0-SNAPSHOT-jar-with-dependencies.jar \
 $CMD_PROPS org.sagebionetworks.template.repo.RepositoryBuilderMain


### PR DESCRIPTION
## Summary

Companion to https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/pull/856.

PLFM-9606 / Synapse-Stack-Builder PR #854 added two unconditional `getIntegerProperty` lookups at the end of `RepositoryTemplateBuilderImpl.createSharedContext` for `org.sagebionetworks.beanstalk.number.repo` and `.workers`. Those keys are not in `repo-defaults.properties` and were not passed by `scripts/build_synapse_dev_stack.sh`, so the **Build Synapse Dev Stack** job dies in `createSharedContext` with `ConfigurationPropertyNotFound` before any environment is built:

```
Exception in thread "main" org.sagebionetworks.template.ConfigurationPropertyNotFound: Missing property value for key: 'org.sagebionetworks.beanstalk.number.repo'
    at org.sagebionetworks.template.config.ConfigurationImpl.getProperty(ConfigurationImpl.java:47)
    at org.sagebionetworks.template.config.ConfigurationImpl.getIntegerProperty(ConfigurationImpl.java:67)
    at org.sagebionetworks.template.repo.RepositoryTemplateBuilderImpl.createSharedContext(RepositoryTemplateBuilderImpl.java:503)
    at org.sagebionetworks.template.repo.RepositoryTemplateBuilderImpl.buildAndDeploy(RepositoryTemplateBuilderImpl.java:206)
    at org.sagebionetworks.template.repo.RepositoryBuilderMain.main(RepositoryBuilderMain.java:20)
```

## Fix

Append `-Dorg.sagebionetworks.beanstalk.number.repo=0 -Dorg.sagebionetworks.beanstalk.number.workers=0` to `CMD_PROPS`. The dev stack only builds shared resources on the BEANSTALK target, where the templates never read these values — `0` is a placeholder that satisfies the new precondition.

## Test plan

- [ ] Run the **Build Synapse Dev Stack** job; the stack-builder invocation should get past `createSharedContext` and complete the shared-resources stack deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)