### PR TITLE
PLFM-9675: Use BUILD_IMAGE parameter

### DIFF
--- a/.github/workflows/code_pipeline_migration_prod_staging.yml
+++ b/.github/workflows/code_pipeline_migration_prod_staging.yml
@@ -21,10 +21,8 @@ jobs:
     steps:
       - name: Determine Pipeline Parameters
         id: pipeline-params
-        # Note: Migration-Utility is incompatible with Java in amazonlinux-x86_64-standard:5.0
-        # so we use amazonlinux-x86_64-standard:corretto11 instead.
         run: |
-          PIPELINE_PARAMETERS="BuildImage=\"aws/codebuild/amazonlinux-x86_64-standard:corretto11\",CommandToExecute=\"scripts/migration_prod_staging.sh ${{ inputs.STACK }} ${{ inputs.REMAIN_READ_ONLY_MODE }} ${{ inputs.SERVICE_KEY }}\""
+          PIPELINE_PARAMETERS="CommandToExecute=\"scripts/migration_prod_staging.sh ${{ inputs.STACK }} ${{ inputs.REMAIN_READ_ONLY_MODE }} ${{ inputs.SERVICE_KEY }}\""
           echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
     outputs:
       PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}
@@ -35,6 +33,9 @@ jobs:
     with:
       PIPELINE_PARAMETERS: ${{ needs.set-up.outputs.PIPELINE_PARAMETERS }}
       SECOND_REPO_NAME: Synapse-Migration-Utility
+      # Note: Migration-Utility is incompatible with Java in amazonlinux-x86_64-standard:5.0
+      # so we use amazonlinux-x86_64-standard:corretto11 instead.
+      BUILD_IMAGE: aws/codebuild/amazonlinux-x86_64-standard:corretto11
     secrets: inherit
     permissions:
       id-token: write


### PR DESCRIPTION
This PR uses the new BUILD_IMAGE parameter instead of passing it through PIPELINE_PARAMETERS (it was getting concatenated with the default value).
